### PR TITLE
Update to rand_core 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Entries are listed in reverse chronological order.
 
+## 4.0.0
+
+* Update to `rand_core` `0.6`.  This requires a major version bump but the API
+  is otherwise unchanged from the `3.x` series.
+
 ## 3.0.1
 
 * Update repository URL.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bulletproofs"
 # - update version field 
 # - update html_root_url
 # - update CHANGELOG
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Cathie Yun <cathieyun@gmail.com>", 
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]
@@ -17,30 +17,30 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "3", default-features = false, features = ["u64_backend", "serde"] }
-subtle = { package = "subtle-ng", version = "2", default-features = false }
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, features = ["u64_backend", "serde"] }
+subtle = { package = "subtle-ng", version = "2.4", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 digest = { version = "0.9.0", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["alloc"] }
-rand = { version = "0.7", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
+rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
-merlin = { version = "2", default-features = false }
+merlin = { version = "3", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 hex = "0.3"
 criterion = "0.3"
 bincode = "1"
-rand_chacha = "0.2"
+rand_chacha = "0.3"
 
 [features]
 default = ["std"]
 avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["rand", "rand/std", "thiserror", "curve25519-dalek/std"]
+std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std"]
 nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(feature = "docs", doc(include = "../README.md"))]
 #![cfg_attr(
     feature = "docs",
-    doc(html_root_url = "https://docs.rs/bulletproofs/3.0.1")
+    doc(html_root_url = "https://docs.rs/bulletproofs/4.0.0")
 )]
 
 extern crate alloc;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -650,7 +650,7 @@ mod tests {
 
             // 0. Create witness data
             let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             // 1. Create the proof


### PR DESCRIPTION
~~This fails because the `thread_rng` is no longer available without
`std`, so we need to handle that.~~ (this just needed slightly different feature flags)

Closes #3 