### PR TITLE
Fixing signature of gen_range api (requires a Range)

### DIFF
--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -175,7 +175,7 @@ fn bench_kshuffle_prove(c: &mut Criterion) {
             let mut rng = rand::thread_rng();
             let (min, max) = (0u64, std::u64::MAX);
             let input: Vec<Scalar> = (0..*k)
-                .map(|_| Scalar::from(rng.gen_range(min, max)))
+                .map(|_| Scalar::from(rng.gen_range(min..max)))
                 .collect();
             let mut output = input.clone();
             output.shuffle(&mut rand::thread_rng());
@@ -217,7 +217,7 @@ fn bench_kshuffle_verify(c: &mut Criterion) {
                 let mut rng = rand::thread_rng();
                 let (min, max) = (0u64, std::u64::MAX);
                 let input: Vec<Scalar> = (0..*k)
-                    .map(|_| Scalar::from(rng.gen_range(min, max)))
+                    .map(|_| Scalar::from(rng.gen_range(min..max)))
                     .collect();
                 let mut output = input.clone();
                 output.shuffle(&mut rand::thread_rng());

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -26,7 +26,7 @@ fn create_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let mut rng = rand::thread_rng();
 
             let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             b.iter(|| {
@@ -74,7 +74,7 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
             let mut rng = rand::thread_rng();
 
             let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+            let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
             let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
 
             let mut transcript = Transcript::new(b"AggregateRangeProofBenchmark");

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -156,7 +156,7 @@ fn kshuffle_helper(k: usize) {
         let mut rng = rand::thread_rng();
         let (min, max) = (0u64, std::u64::MAX);
         let input: Vec<Scalar> = (0..k)
-            .map(|_| Scalar::from(rng.gen_range(min, max)))
+            .map(|_| Scalar::from(rng.gen_range(min..max)))
             .collect();
         let mut output = input.clone();
         output.shuffle(&mut rand::thread_rng());
@@ -411,7 +411,7 @@ fn range_proof_gadget() {
 
     for n in [2, 10, 32, 63].iter() {
         let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
-        let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min, max)).collect();
+        let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
         for v in values {
             assert!(range_proof_helper(v.into(), *n).is_ok());
         }


### PR DESCRIPTION
After updating `rand_core` dependency, the new api for `gen_range` requires a `Range` as an input.
Some tests and benchmarks were left with the previous `(min, max)`.