### PR TITLE
Change dependency on curve25519-dalek-ng to curve25519-dalek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+## 5.0.0
+
+* Change `curve25519-dalek-ng` dependency to `curve25519-dalek`. A major version bump is required because one cannot import `curve25519-dalek` and `bulletproofs` without conflicts.
+
 ## 4.0.0
 
 * Update to `rand_core` `0.6`.  This requires a major version bump but the API
@@ -39,7 +43,7 @@ Entries are listed in reverse chronological order.
 * Updates the library to use the renamed functions in Merlin 1.1.
 * Adds additional validation checks to prevent identity points being used as
   part of a proof.  This does not appear to have security content, but is
-  intended as a defense-in-depth mechanism.  
+  intended as a defense-in-depth mechanism.
   See [this comment][identity_comment] for more motivation.
 * Documentation tweaks.
 
@@ -52,7 +56,7 @@ Entries are listed in reverse chronological order.
 
 ## 1.0.0
 
-* Minor tweaks to the prerelease version.  
+* Minor tweaks to the prerelease version.
 * Preliminary support for R1CS proofs, but this feature is hard-disabled in the
   published crate.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, features = ["u64_backend", "serde"] }
+curve25519-dalek = { version = "4.1.1", default-features = false, features = ["serde"] }
 subtle = { package = "subtle-ng", version = "2.4", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 digest = { version = "0.9.0", default-features = false }
@@ -38,10 +38,9 @@ rand_chacha = "0.3"
 
 [features]
 default = ["std"]
-avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
+std = ["rand", "rand/std", "rand/std_rng", "thiserror"]
+nightly = ["curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "bulletproofs"
 # - update version field
 # - update html_root_url
 # - update CHANGELOG
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Cathie Yun <cathieyun@gmail.com>",
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "serde"] }
+curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "rand_core", "serde"] }
 subtle = { package = "subtle-ng", version = "2.4", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "4.1.1", default-features = false, features = ["serde"] }
+curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "serde"] }
 subtle = { package = "subtle-ng", version = "2.4", default-features = false }
-sha3 = { version = "0.9.1", default-features = false }
-digest = { version = "0.9.0", default-features = false }
+sha3 = { version = "0.10.8", default-features = false }
+digest = { version = "0.10.7", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
@@ -40,7 +40,7 @@ rand_chacha = "0.3"
 default = ["std"]
 yoloproofs = []
 std = ["rand", "rand/std", "rand/std_rng", "thiserror"]
-nightly = ["curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
+nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 
 
@@ -54,7 +54,6 @@ required-features = ["yoloproofs"]
 [[bench]]
 name = "range_proof"
 harness = false
-required-features = ["avx2_backend"]
 
 [[bench]]
 name = "generators"
@@ -63,7 +62,7 @@ harness = false
 [[bench]]
 name = "r1cs"
 harness = false
-required-features = ["yoloproofs", "avx2_backend"]
+required-features = ["yoloproofs"]
 
 [[bench]]
 name = "linear_proof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "rand_core", "serde"] }
-subtle = { package = "subtle-ng", version = "2.4", default-features = false }
+curve25519-dalek = { version = "4.1.1", features = ["digest", "group", "rand_core", "serde"] }
+group = { version = "0.13", default-features = false }
+subtle = { version = "2.5", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 digest = { version = "0.10.7", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ hex = "0.3"
 criterion = "0.3"
 bincode = "1"
 rand_chacha = "0.3"
+curve25519-dalek = { version = "4.1.1", features = ["digest", "group", "legacy_compatibility", "rand_core", "serde"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bulletproofs"
 # Before doing a release:
-# - update version field 
+# - update version field
 # - update html_root_url
 # - update CHANGELOG
 version = "4.0.0"
-authors = ["Cathie Yun <cathieyun@gmail.com>", 
+authors = ["Cathie Yun <cathieyun@gmail.com>",
            "Henry de Valence <hdevalence@hdevalence.ca>",
            "Oleg Andreev <oleganza@gmail.com>"]
 readme = "README.md"
@@ -20,8 +20,8 @@ edition = "2018"
 curve25519-dalek = { version = "4.1.1", features = ["digest", "group", "rand_core", "serde"] }
 group = { version = "0.13", default-features = false }
 subtle = { version = "2.5", default-features = false }
-sha3 = { version = "0.10.8", default-features = false }
-digest = { version = "0.10.7", default-features = false }
+sha3 = { version = "0.10", default-features = false }
+digest = { version = "0.10", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 rand = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }

--- a/benches/linear_proof.rs
+++ b/benches/linear_proof.rs
@@ -79,7 +79,7 @@ fn create_linear_proof_helper(c: &mut Criterion) {
 /// \\]
 /// Panics if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 fn inner_product(a: &[Scalar], b: &[Scalar]) -> Scalar {
-    let mut out = Scalar::zero();
+    let mut out = Scalar::ZERO;
     if a.len() != b.len() {
         panic!("inner_product(a,b): lengths of vectors do not match");
     }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -11,8 +11,9 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
-use digest::{ExtendableOutputDirty, Update, XofReader};
-use sha3::{Sha3XofReader, Sha3_512, Shake256};
+use curve25519_dalek::traits::MultiscalarMul;
+use digest::{ExtendableOutput, Update, XofReader};
+use sha3::{Sha3_512, Shake256, Shake256Reader};
 
 /// Represents a pair of base points for Pedersen commitments.
 ///
@@ -55,7 +56,7 @@ impl Default for PedersenGens {
 /// orthogonal generators.  The sequence can be deterministically
 /// produced starting with an arbitrary point.
 struct GeneratorsChain {
-    reader: Sha3XofReader,
+    reader: Shake256Reader,
 }
 
 impl GeneratorsChain {
@@ -66,7 +67,7 @@ impl GeneratorsChain {
         shake.update(label);
 
         GeneratorsChain {
-            reader: shake.finalize_xof_dirty(),
+            reader: shake.finalize_xof(),
         }
     }
 

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -11,7 +11,6 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::MultiscalarMul;
 use digest::{ExtendableOutputDirty, Update, XofReader};
 use sha3::{Sha3XofReader, Sha3_512, Shake256};
 

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -398,9 +398,9 @@ impl InnerProductProof {
         }
 
         let pos = 2 * lg_n * 32;
-        let a =
-            Scalar::from_canonical_bytes(read32(&slice[pos..])).ok_or(ProofError::FormatError)?;
-        let b = Scalar::from_canonical_bytes(read32(&slice[pos + 32..]))
+        let a = Option::from(Scalar::from_canonical_bytes(read32(&slice[pos..])))
+            .ok_or(ProofError::FormatError)?;
+        let b = Option::from(Scalar::from_canonical_bytes(read32(&slice[pos + 32..])))
             .ok_or(ProofError::FormatError)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -446,7 +446,7 @@ mod tests {
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
         let c = inner_product(&a, &b);
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(n).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(n).collect();
 
         // y_inv is (the inverse of) a random challenge
         let y_inv = Scalar::random(&mut rng);
@@ -483,7 +483,7 @@ mod tests {
             .verify(
                 n,
                 &mut verifier,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,
@@ -498,7 +498,7 @@ mod tests {
             .verify(
                 n,
                 &mut verifier,
-                iter::repeat(Scalar::one()).take(n),
+                iter::repeat(Scalar::ONE).take(n),
                 util::exp_iter(y_inv).take(n),
                 &P,
                 &Q,

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -9,7 +9,6 @@ use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::VartimeMultiscalarMul;
 use merlin::Transcript;
 
 use crate::errors::ProofError;

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -9,6 +9,7 @@ use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::VartimeMultiscalarMul;
 use merlin::Transcript;
 
 use crate::errors::ProofError;

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -413,7 +413,7 @@ impl InnerProductProof {
 /// \\]
 /// Panics if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Scalar {
-    let mut out = Scalar::zero();
+    let mut out = Scalar::ZERO;
     if a.len() != b.len() {
         panic!("inner_product(a,b): lengths of vectors do not match");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(feature = "docs", doc(include = "../README.md"))]
 #![cfg_attr(
     feature = "docs",
-    doc(html_root_url = "https://docs.rs/bulletproofs/4.0.0")
+    doc(html_root_url = "https://docs.rs/bulletproofs/5.0.0")
 )]
 
 extern crate alloc;

--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -7,7 +7,6 @@ use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::VartimeMultiscalarMul;
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 

--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -133,7 +133,7 @@ impl LinearProof {
                 b_L[i] = b_L[i] + x_j * b_R[i];
                 // G_L = G_L + x_j * G_R
                 G_L[i] = RistrettoPoint::vartime_multiscalar_mul(
-                    &[Scalar::one(), x_j],
+                    &[Scalar::ONE, x_j],
                     &[G_L[i], G_R[i]],
                 );
             }
@@ -300,7 +300,7 @@ impl LinearProof {
         let lg_n = self.L_vec.len();
 
         let mut s = Vec::with_capacity(n);
-        s.push(Scalar::one());
+        s.push(Scalar::ONE);
         for i in 1..n {
             let lg_i = (32 - 1 - (i as u32).leading_zeros()) as usize;
             let k = 1 << lg_i;

--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::VartimeMultiscalarMul;
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 

--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -391,9 +391,9 @@ impl LinearProof {
 
         let pos = 2 * lg_n * 32;
         let S = CompressedRistretto(read32(&slice[pos..]));
-        let a = Scalar::from_canonical_bytes(read32(&slice[pos + 32..]))
+        let a = Option::from(Scalar::from_canonical_bytes(read32(&slice[pos + 32..])))
             .ok_or(ProofError::FormatError)?;
-        let r = Scalar::from_canonical_bytes(read32(&slice[pos + 64..]))
+        let r = Option::from(Scalar::from_canonical_bytes(read32(&slice[pos + 64..])))
             .ok_or(ProofError::FormatError)?;
 
         Ok(LinearProof {

--- a/src/r1cs/linear_combination.rs
+++ b/src/r1cs/linear_combination.rs
@@ -22,7 +22,7 @@ pub enum Variable {
 impl From<Variable> for LinearCombination {
     fn from(v: Variable) -> LinearCombination {
         LinearCombination {
-            terms: vec![(v, Scalar::one())],
+            terms: vec![(v, Scalar::ONE)],
         }
     }
 }
@@ -78,7 +78,7 @@ impl Add<Variable> for Scalar {
 
     fn add(self, other: Variable) -> Self::Output {
         LinearCombination {
-            terms: vec![(Variable::One(), self), (other, Scalar::one())],
+            terms: vec![(Variable::One(), self), (other, Scalar::ONE)],
         }
     }
 }
@@ -88,7 +88,7 @@ impl Sub<Variable> for Scalar {
 
     fn sub(self, other: Variable) -> Self::Output {
         LinearCombination {
-            terms: vec![(Variable::One(), self), (other, -Scalar::one())],
+            terms: vec![(Variable::One(), self), (other, -Scalar::ONE)],
         }
     }
 }

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -120,8 +120,8 @@ impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for Prover<'g, T> {
         self.secrets.a_O.push(o);
 
         // Constrain l,r,o:
-        left.terms.push((l_var, -Scalar::one()));
-        right.terms.push((r_var, -Scalar::one()));
+        left.terms.push((l_var, -Scalar::ONE));
+        right.terms.push((r_var, -Scalar::ONE));
         self.constrain(left);
         self.constrain(right);
 
@@ -365,7 +365,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
                         Variable::MultiplierRight(i) => self.secrets.a_R[*i],
                         Variable::MultiplierOutput(i) => self.secrets.a_O[*i],
                         Variable::Committed(i) => self.secrets.v[*i],
-                        Variable::One() => Scalar::one(),
+                        Variable::One() => Scalar::ONE,
                     }
             })
             .sum()
@@ -580,7 +580,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         let mut l_poly = util::VecPoly3::zero(n);
         let mut r_poly = util::VecPoly3::zero(n);
 
-        let mut exp_y = Scalar::one(); // y^n starting at n=0
+        let mut exp_y = Scalar::ONE; // y^n starting at n=0
         let y_inv = y.invert();
         let exp_y_inv = util::exp_iter(y_inv).take(padded_n).collect::<Vec<_>>();
 
@@ -676,7 +676,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         let w = transcript.challenge_scalar(b"w");
         let Q = w * self.pc_gens.B;
 
-        let G_factors = iter::repeat(Scalar::one())
+        let G_factors = iter::repeat(Scalar::ONE)
             .take(n1)
             .chain(iter::repeat(u).take(n2 + pad))
             .collect::<Vec<_>>();

--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -136,8 +136,8 @@ impl<'g, T: BorrowMut<Transcript>> ConstraintSystem for Prover<'g, T> {
                 let i = self.secrets.a_L.len();
                 self.pending_multiplier = Some(i);
                 self.secrets.a_L.push(scalar);
-                self.secrets.a_R.push(Scalar::zero());
-                self.secrets.a_O.push(Scalar::zero());
+                self.secrets.a_R.push(Scalar::ZERO);
+                self.secrets.a_O.push(Scalar::ZERO);
                 Ok(Variable::MultiplierLeft(i))
             }
             Some(i) => {
@@ -322,10 +322,10 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         let n = self.secrets.a_L.len();
         let m = self.secrets.v.len();
 
-        let mut wL = vec![Scalar::zero(); n];
-        let mut wR = vec![Scalar::zero(); n];
-        let mut wO = vec![Scalar::zero(); n];
-        let mut wV = vec![Scalar::zero(); m];
+        let mut wL = vec![Scalar::ZERO; n];
+        let mut wR = vec![Scalar::ZERO; n];
+        let mut wO = vec![Scalar::ZERO; n];
+        let mut wV = vec![Scalar::ZERO; m];
 
         let mut exp_z = *z;
         for lc in self.constraints.iter() {
@@ -518,7 +518,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
                 Scalar::random(&mut rng),
             )
         } else {
-            (Scalar::zero(), Scalar::zero(), Scalar::zero())
+            (Scalar::ZERO, Scalar::ZERO, Scalar::ZERO)
         };
 
         let mut s_L2: Vec<Scalar> = (0..n2).map(|_| Scalar::random(&mut rng)).collect();
@@ -651,10 +651,10 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         let t_x = t_poly.eval(x);
         let t_x_blinding = t_blinding_poly.eval(x);
         let mut l_vec = l_poly.eval(x);
-        l_vec.append(&mut vec![Scalar::zero(); pad]);
+        l_vec.append(&mut vec![Scalar::ZERO; pad]);
 
         let mut r_vec = r_poly.eval(x);
-        r_vec.append(&mut vec![Scalar::zero(); pad]);
+        r_vec.append(&mut vec![Scalar::ZERO; pad]);
 
         // XXX this should refer to the notes to explain why this is correct
         for i in n..padded_n {

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -81,8 +81,8 @@ impl<T: BorrowMut<Transcript>> ConstraintSystem for Verifier<T> {
         let o_var = Variable::MultiplierOutput(var);
 
         // Constrain l,r,o:
-        left.terms.push((l_var, -Scalar::one()));
-        right.terms.push((r_var, -Scalar::one()));
+        left.terms.push((l_var, -Scalar::ONE));
+        right.terms.push((r_var, -Scalar::ONE));
         self.constrain(left);
         self.constrain(right);
 
@@ -433,7 +433,7 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
 
         let delta = inner_product(&yneg_wR[0..n], &wL);
 
-        let u_for_g = iter::repeat(Scalar::one())
+        let u_for_g = iter::repeat(Scalar::ONE)
             .take(n1)
             .chain(iter::repeat(u).take(n2 + pad));
         let u_for_h = u_for_g.clone();
@@ -452,7 +452,7 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
             .zip(wL.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
             .zip(wO.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
             .map(|((((y_inv_i, u_or_1), s_i_inv), wLi), wOi)| {
-                u_or_1 * (y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::one())
+                u_or_1 * (y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::ONE)
             });
 
         // Create a `TranscriptRng` from the transcript. The verifier

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -275,11 +275,11 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
         let n = self.num_vars;
         let m = self.V.len();
 
-        let mut wL = vec![Scalar::zero(); n];
-        let mut wR = vec![Scalar::zero(); n];
-        let mut wO = vec![Scalar::zero(); n];
-        let mut wV = vec![Scalar::zero(); m];
-        let mut wc = Scalar::zero();
+        let mut wL = vec![Scalar::ZERO; n];
+        let mut wR = vec![Scalar::ZERO; n];
+        let mut wO = vec![Scalar::ZERO; n];
+        let mut wV = vec![Scalar::ZERO; m];
+        let mut wc = Scalar::ZERO;
 
         let mut exp_z = *z;
         for lc in self.constraints.iter() {
@@ -428,7 +428,7 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
             .into_iter()
             .zip(y_inv_vec.iter())
             .map(|(wRi, exp_y_inv)| wRi * exp_y_inv)
-            .chain(iter::repeat(Scalar::zero()).take(pad))
+            .chain(iter::repeat(Scalar::ZERO).take(pad))
             .collect::<Vec<Scalar>>();
 
         let delta = inner_product(&yneg_wR[0..n], &wL);
@@ -449,8 +449,8 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
             .iter()
             .zip(u_for_h)
             .zip(s.iter().rev().take(padded_n))
-            .zip(wL.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
-            .zip(wO.into_iter().chain(iter::repeat(Scalar::zero()).take(pad)))
+            .zip(wL.into_iter().chain(iter::repeat(Scalar::ZERO).take(pad)))
+            .zip(wO.into_iter().chain(iter::repeat(Scalar::ZERO).take(pad)))
             .map(|((((y_inv_i, u_or_1), s_i_inv), wLi), wOi)| {
                 u_or_1 * (y_inv_i * (x * wLi + wOi - b * s_i_inv) - Scalar::ONE)
             });

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -255,7 +255,7 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
         let w = self.transcript.challenge_scalar(b"w");
         let Q = w * self.pc_gens.B;
 
-        let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(self.n * self.m).collect();
+        let G_factors: Vec<Scalar> = iter::repeat(Scalar::ONE).take(self.n * self.m).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(self.bit_challenge.y.invert())
             .take(self.n * self.m)
             .collect();

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -126,7 +126,7 @@ impl ProofShare {
             });
 
         let P_check = RistrettoPoint::vartime_multiscalar_mul(
-            iter::once(Scalar::one())
+            iter::once(Scalar::ONE)
                 .chain(iter::once(*x))
                 .chain(iter::once(-self.e_blinding))
                 .chain(g)

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 use crate::generators::{BulletproofGens, PedersenGens};
 

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -94,6 +94,8 @@ impl ProofShare {
     ) -> Result<(), ()> {
         use crate::inner_product_proof::inner_product;
         use crate::util;
+        use core::ops::Not;
+        use group::Group;
 
         let n = self.l_vec.len();
 
@@ -136,7 +138,7 @@ impl ProofShare {
                 .chain(bp_gens.share(j).G(n))
                 .chain(bp_gens.share(j).H(n)),
         );
-        if !P_check.is_identity() {
+        if P_check.is_identity().not().into() {
             return Err(());
         }
 
@@ -158,7 +160,7 @@ impl ProofShare {
                 .chain(iter::once(&pc_gens.B_blinding)),
         );
 
-        if t_check.is_identity() {
+        if t_check.is_identity().into() {
             Ok(())
         } else {
             Err(())

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -91,8 +91,6 @@ impl ProofShare {
         poly_commitment: &PolyCommitment,
         poly_challenge: &PolyChallenge,
     ) -> Result<(), ()> {
-        use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
-
         use crate::inner_product_proof::inner_product;
         use crate::util;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -13,7 +13,6 @@ use core::iter;
 
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::{IsIdentity, VartimeMultiscalarMul};
 use merlin::Transcript;
 
 use crate::errors::ProofError;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -515,11 +515,11 @@ impl RangeProof {
         let T_1 = CompressedRistretto(read32(&slice[2 * 32..]));
         let T_2 = CompressedRistretto(read32(&slice[3 * 32..]));
 
-        let t_x = Scalar::from_canonical_bytes(read32(&slice[4 * 32..]))
+        let t_x = Option::from(Scalar::from_canonical_bytes(read32(&slice[4 * 32..])))
             .ok_or(ProofError::FormatError)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(read32(&slice[5 * 32..]))
+        let t_x_blinding = Option::from(Scalar::from_canonical_bytes(read32(&slice[5 * 32..])))
             .ok_or(ProofError::FormatError)?;
-        let e_blinding = Scalar::from_canonical_bytes(read32(&slice[6 * 32..]))
+        let e_blinding = Option::from(Scalar::from_canonical_bytes(read32(&slice[6 * 32..])))
             .ok_or(ProofError::FormatError)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -611,7 +611,7 @@ mod tests {
         // code copied from previous implementation
         let z2 = z * z;
         let z3 = z2 * z;
-        let mut power_g = Scalar::zero();
+        let mut power_g = Scalar::ZERO;
         let mut exp_y = Scalar::ONE; // start at y^0 = 1
         let mut exp_2 = Scalar::ONE; // start at 2^0 = 1
         for _ in 0..n {
@@ -832,7 +832,7 @@ mod tests {
             dealer.receive_poly_commitments(vec![poly_com0]).unwrap();
 
         // But now simulate a malicious dealer choosing x = 0
-        poly_challenge.x = Scalar::zero();
+        poly_challenge.x = Scalar::ZERO;
 
         let maybe_share0 = party0.apply_challenge(&poly_challenge);
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -419,7 +419,7 @@ impl RangeProof {
         let basepoint_scalar = w * (self.t_x - a * b) + c * (delta(n, m, &y, &z) - self.t_x);
 
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
-            iter::once(Scalar::one())
+            iter::once(Scalar::ONE)
                 .chain(iter::once(x))
                 .chain(iter::once(c * x))
                 .chain(iter::once(c * x * x))
@@ -612,8 +612,8 @@ mod tests {
         let z2 = z * z;
         let z3 = z2 * z;
         let mut power_g = Scalar::zero();
-        let mut exp_y = Scalar::one(); // start at y^0 = 1
-        let mut exp_2 = Scalar::one(); // start at 2^0 = 1
+        let mut exp_y = Scalar::ONE; // start at y^0 = 1
+        let mut exp_2 = Scalar::ONE; // start at 2^0 = 1
         for _ in 0..n {
             power_g += (z - z2) * exp_y - z3 * exp_2;
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -417,6 +417,7 @@ impl RangeProof {
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| c * zz * z_exp);
         let basepoint_scalar = w * (self.t_x - a * b) + c * (delta(n, m, &y, &z) - self.t_x);
 
+        use curve25519_dalek::traits::VartimeMultiscalarMul;
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
             iter::once(Scalar::ONE)
                 .chain(iter::once(x))
@@ -443,7 +444,8 @@ impl RangeProof {
         )
         .ok_or_else(|| ProofError::VerificationError)?;
 
-        if mega_check.is_identity() {
+        use group::Group;
+        if mega_check.is_identity().into() {
             Ok(())
         } else {
             Err(ProofError::VerificationError)

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -279,7 +279,7 @@ impl PartyAwaitingPolyChallenge {
     pub fn apply_challenge(self, pc: &PolyChallenge) -> Result<ProofShare, MPCError> {
         // Prevent a malicious dealer from annihilating the blinding
         // factors by supplying a zero challenge.
-        if pc.x == Scalar::zero() {
+        if pc.x == Scalar::ZERO {
             return Err(MPCError::MaliciousDealer);
         }
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -194,10 +194,10 @@ impl<'a> PartyAwaitingBitChallenge<'a> {
 
         let offset_zz = vc.z * vc.z * offset_z;
         let mut exp_y = offset_y; // start at y^j
-        let mut exp_2 = Scalar::one(); // start at 2^0 = 1
+        let mut exp_2 = Scalar::ONE; // start at 2^0 = 1
         for i in 0..n {
             let a_L_i = Scalar::from((self.v >> i) & 1);
-            let a_R_i = a_L_i - Scalar::one();
+            let a_R_i = a_L_i - Scalar::ONE;
 
             l_poly.0[i] = a_L_i - vc.z;
             l_poly.1[i] = self.s_L[i];

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -17,7 +17,6 @@ use clear_on_drop::clear::Clear;
 use core::iter;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use curve25519_dalek::traits::MultiscalarMul;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::errors::MPCError;
@@ -99,7 +98,7 @@ impl<'a> PartyAwaitingPosition<'a> {
         // Compute A = <a_L, G> + <a_R, H> + a_blinding * B_blinding
         let mut A = self.pc_gens.B_blinding * a_blinding;
 
-        use subtle::{Choice, ConditionallySelectable};
+        use subtle::Choice;
         let mut i = 0;
         for (G_i, H_i) in bp_share.G(self.n).zip(bp_share.H(self.n)) {
             // If v_i = 0, we add a_L[i] * G[i] + a_R[i] * H[i] = - H[i]

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
         // throw some error
         //println!("lengths of vectors don't match for vector addition");
     }
-    let mut out = vec![Scalar::zero(); b.len()];
+    let mut out = vec![Scalar::ZERO; b.len()];
     for i in 0..a.len() {
         out[i] = a[i] + b[i];
     }
@@ -80,7 +80,7 @@ pub fn add_vec(a: &[Scalar], b: &[Scalar]) -> Vec<Scalar> {
 
 impl VecPoly1 {
     pub fn zero(n: usize) -> Self {
-        VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
+        VecPoly1(vec![Scalar::ZERO; n], vec![Scalar::ZERO; n])
     }
 
     pub fn inner_product(&self, rhs: &VecPoly1) -> Poly2 {
@@ -101,7 +101,7 @@ impl VecPoly1 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out = vec![Scalar::ZERO; n];
         for i in 0..n {
             out[i] = self.0[i] + self.1[i] * x;
         }
@@ -113,10 +113,10 @@ impl VecPoly1 {
 impl VecPoly3 {
     pub fn zero(n: usize) -> Self {
         VecPoly3(
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
-            vec![Scalar::zero(); n],
+            vec![Scalar::ZERO; n],
+            vec![Scalar::ZERO; n],
+            vec![Scalar::ZERO; n],
+            vec![Scalar::ZERO; n],
         )
     }
 
@@ -146,7 +146,7 @@ impl VecPoly3 {
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
         let n = self.0.len();
-        let mut out = vec![Scalar::zero(); n];
+        let mut out = vec![Scalar::ZERO; n];
         for i in 0..n {
             out[i] = self.0[i] + x * (self.1[i] + x * (self.2[i] + x * self.3[i]));
         }
@@ -341,7 +341,7 @@ mod tests {
     #[test]
     fn test_sum_of_powers_slow() {
         let x = Scalar::from(10u64);
-        assert_eq!(sum_of_powers_slow(&x, 0), Scalar::zero());
+        assert_eq!(sum_of_powers_slow(&x, 0), Scalar::ZERO);
         assert_eq!(sum_of_powers_slow(&x, 1), Scalar::ONE);
         assert_eq!(sum_of_powers_slow(&x, 2), Scalar::from(11u64));
         assert_eq!(sum_of_powers_slow(&x, 3), Scalar::from(111u64));
@@ -366,8 +366,8 @@ mod tests {
         }
 
         assert_eq!(flat_slice(&v.as_slice()), &[0u8; 64][..]);
-        assert_eq!(v[0], Scalar::zero());
-        assert_eq!(v[1], Scalar::zero());
+        assert_eq!(v[0], Scalar::ZERO);
+        assert_eq!(v[1], Scalar::ZERO);
     }
 
     #[test]
@@ -390,8 +390,8 @@ mod tests {
         }
 
         assert_eq!(as_bytes(&v), &[0u8; 96][..]);
-        assert_eq!(v.0, Scalar::zero());
-        assert_eq!(v.1, Scalar::zero());
-        assert_eq!(v.2, Scalar::zero());
+        assert_eq!(v.0, Scalar::ZERO);
+        assert_eq!(v.1, Scalar::ZERO);
+        assert_eq!(v.2, Scalar::ZERO);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,7 @@ impl Iterator for ScalarExp {
 
 /// Return an iterator of the powers of `x`.
 pub fn exp_iter(x: Scalar) -> ScalarExp {
-    let next_exp_x = Scalar::one();
+    let next_exp_x = Scalar::ONE;
     ScalarExp { x, next_exp_x }
 }
 
@@ -220,7 +220,7 @@ impl Drop for Poly6 {
 /// with (1 to 2)*lg(n) scalar multiplications.
 /// TODO: a consttime version of this would be awfully similar to a Montgomery ladder.
 pub fn scalar_exp_vartime(x: &Scalar, mut n: u64) -> Scalar {
-    let mut result = Scalar::one();
+    let mut result = Scalar::ONE;
     let mut aux = *x; // x, x^2, x^4, x^8, ...
     while n > 0 {
         let bit = n & 1;
@@ -245,7 +245,7 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
         return Scalar::from(n as u64);
     }
     let mut m = n;
-    let mut result = Scalar::one() + x;
+    let mut result = Scalar::ONE + x;
     let mut factor = *x;
     while m > 2 {
         factor = factor * factor;
@@ -300,7 +300,7 @@ mod tests {
 
     /// Raises `x` to the power `n`.
     fn scalar_exp_vartime_slow(x: &Scalar, n: u64) -> Scalar {
-        let mut result = Scalar::one();
+        let mut result = Scalar::ONE;
         for _ in 0..n {
             result = result * x;
         }
@@ -312,7 +312,7 @@ mod tests {
         let x = Scalar::from_bits(
             *b"\x84\xfc\xbcOx\x12\xa0\x06\xd7\x91\xd9z:'\xdd\x1e!CE\xf7\xb1\xb9Vz\x810sD\x96\x85\xb5\x07",
         );
-        assert_eq!(scalar_exp_vartime(&x, 0), Scalar::one());
+        assert_eq!(scalar_exp_vartime(&x, 0), Scalar::ONE);
         assert_eq!(scalar_exp_vartime(&x, 1), x);
         assert_eq!(scalar_exp_vartime(&x, 2), x * x);
         assert_eq!(scalar_exp_vartime(&x, 3), x * x * x);
@@ -342,7 +342,7 @@ mod tests {
     fn test_sum_of_powers_slow() {
         let x = Scalar::from(10u64);
         assert_eq!(sum_of_powers_slow(&x, 0), Scalar::zero());
-        assert_eq!(sum_of_powers_slow(&x, 1), Scalar::one());
+        assert_eq!(sum_of_powers_slow(&x, 1), Scalar::ONE);
         assert_eq!(sum_of_powers_slow(&x, 2), Scalar::from(11u64));
         assert_eq!(sum_of_powers_slow(&x, 3), Scalar::from(111u64));
         assert_eq!(sum_of_powers_slow(&x, 4), Scalar::from(1111u64));

--- a/tests/r1cs.rs
+++ b/tests/r1cs.rs
@@ -373,7 +373,7 @@ pub fn range_proof<CS: ConstraintSystem>(
     v_assignment: Option<u64>,
     n: usize,
 ) -> Result<(), R1CSError> {
-    let mut exp_2 = Scalar::one();
+    let mut exp_2 = Scalar::ONE;
     for i in 0..n {
         // Create low-level variables and add them to constraints
         let (a, b, o) = cs.allocate_multiplier(v_assignment.map(|q| {

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -42,7 +42,7 @@ fn deserialize_and_verify() {
         ],
     ];
 
-    let vc = [
+    let vc: Vec<CompressedRistretto> = Vec::from([
         CompressedRistretto::from_slice(
             &hex::decode("90b0c2fe57934dff9f5396e135e7d72b82b3c5393e1843178918eb2cf28a5f3c")
                 .unwrap(),
@@ -75,7 +75,7 @@ fn deserialize_and_verify() {
             &hex::decode("30beef3b58fd2c18dde771d5c77e32f8dc01361e284aef517bce54a5c74c4665")
                 .unwrap(),
         ),
-    ];
+    ]).iter().map(|res| res.unwrap()).collect();
 
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(64, 8);


### PR DESCRIPTION
Closes https://github.com/zkcrypto/bulletproofs/issues/15

@cathieyun 

The major version has to be bumped because importing both Bulletproofs & curve25519-dalek-ng after this change will result in conflicts.

I ran both the tests and benches:
```bash
cargo test
cargo bench
```

I also tested that importing Bulletproofs 5.0.0 & curve25519-dalek 4.1.1 compiles successfully (some changes may need to be done, depending on how curve25519-dalek is used.