### PR TITLE
Cargo fmt to fix check-stable tests

### DIFF
--- a/src/linear_proof.rs
+++ b/src/linear_proof.rs
@@ -132,10 +132,8 @@ impl LinearProof {
                 // b_L = b_L + x_j * b_R
                 b_L[i] = b_L[i] + x_j * b_R[i];
                 // G_L = G_L + x_j * G_R
-                G_L[i] = RistrettoPoint::vartime_multiscalar_mul(
-                    &[Scalar::ONE, x_j],
-                    &[G_L[i], G_R[i]],
-                );
+                G_L[i] =
+                    RistrettoPoint::vartime_multiscalar_mul(&[Scalar::ONE, x_j], &[G_L[i], G_R[i]]);
             }
             a = a_L;
             b = b_L;

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -75,7 +75,10 @@ fn deserialize_and_verify() {
             &hex::decode("30beef3b58fd2c18dde771d5c77e32f8dc01361e284aef517bce54a5c74c4665")
                 .unwrap(),
         ),
-    ]).iter().map(|res| res.unwrap()).collect();
+    ])
+    .iter()
+    .map(|res| res.unwrap())
+    .collect();
 
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(64, 8);


### PR DESCRIPTION
Run `cargo fmt` to fix failing check-stable tests, see:
https://github.com/zkcrypto/bulletproofs/actions/runs/7811044079/job/21305454379