### PR TITLE
Fix build error when "yoloproofs" enabled

### DIFF
--- a/.github/workflows/check-main.yml
+++ b/.github/workflows/check-main.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Cargo fmt
       run: cargo fmt --all -- --check
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --features="yoloproofs" --verbose
     - name: Build benchmarks
-      run: cargo bench --verbose DONTRUNBENCHMARKS
+      run: cargo bench --features="yoloproofs" --verbose DONTRUNBENCHMARKS
 
   check-nightly:
 
@@ -38,6 +38,6 @@ jobs:
           toolchain: nightly
           override: true
     - name: Run tests
-      run: cargo test --features="std,nightly" --verbose
+      run: cargo test --features="std,nightly,yoloproofs" --verbose
     - name: Build benchmarks
-      run: cargo bench --features="std,nightly" --verbose DONTRUNBENCHMARKS
+      run: cargo bench --features="std,nightly,yoloproofs" --verbose DONTRUNBENCHMARKS

--- a/src/r1cs/proof.rs
+++ b/src/r1cs/proof.rs
@@ -177,9 +177,12 @@ impl R1CSProof {
         let T_4 = CompressedRistretto(read32!());
         let T_5 = CompressedRistretto(read32!());
         let T_6 = CompressedRistretto(read32!());
-        let t_x = Scalar::from_canonical_bytes(read32!()).ok_or(R1CSError::FormatError)?;
-        let t_x_blinding = Scalar::from_canonical_bytes(read32!()).ok_or(R1CSError::FormatError)?;
-        let e_blinding = Scalar::from_canonical_bytes(read32!()).ok_or(R1CSError::FormatError)?;
+        let t_x =
+            Option::from(Scalar::from_canonical_bytes(read32!())).ok_or(R1CSError::FormatError)?;
+        let t_x_blinding =
+            Option::from(Scalar::from_canonical_bytes(read32!())).ok_or(R1CSError::FormatError)?;
+        let e_blinding =
+            Option::from(Scalar::from_canonical_bytes(read32!())).ok_or(R1CSError::FormatError)?;
 
         // XXX: IPPProof from_bytes gives ProofError.
         let ipp_proof = InnerProductProof::from_bytes(slice).map_err(|_| R1CSError::FormatError)?;


### PR DESCRIPTION
Currently, the crate doesn't build with "yoloproofs" enabled.
```
error[E0599]: no method named `ok_or` found for struct `CtOption` in the current scope
   --> src/r1cs/proof.rs:180:59
    |
180 |         let t_x = Scalar::from_canonical_bytes(read32!()).ok_or(R1CSError::FormatError)?;
    |                                                           ^^^^^ method not found in `CtOption<Scalar>`
```

Since curve25519-dalek v4, `from_canonical_bytes` returns `CtOption`.
Solution: Wrap with `Option::from`.