### PR TITLE
delete `clear_on_drop` dependency, replace it by `zeroize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "3", default-features = false }
-clear_on_drop = { version = "0.2", default-features = false }
+zeroize = "1.8.1"
 
 [dev-dependencies]
 hex = "0.3"
@@ -42,7 +42,7 @@ curve25519-dalek = { version = "4.1.1", features = ["digest", "group", "legacy_c
 default = ["std"]
 yoloproofs = []
 std = ["rand", "rand/std", "rand/std_rng", "thiserror"]
-nightly = ["subtle/nightly", "clear_on_drop/nightly"]
+nightly = ["subtle/nightly"]
 docs = ["nightly"]
 
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,17 +5,19 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
-use clear_on_drop::clear::Clear;
 use curve25519_dalek::scalar::Scalar;
+use zeroize::ZeroizeOnDrop;
 
 use crate::inner_product_proof::inner_product;
 
 /// Represents a degree-1 vector polynomial \\(\mathbf{a} + \mathbf{b} \cdot x\\).
+#[derive(ZeroizeOnDrop)]
 pub struct VecPoly1(pub Vec<Scalar>, pub Vec<Scalar>);
 
 /// Represents a degree-3 vector polynomial
 /// \\(\mathbf{a} + \mathbf{b} \cdot x + \mathbf{c} \cdot x^2 + \mathbf{d} \cdot x^3 \\).
 #[cfg(feature = "yoloproofs")]
+#[derive(ZeroizeOnDrop)]
 pub struct VecPoly3(
     pub Vec<Scalar>,
     pub Vec<Scalar>,
@@ -24,6 +26,7 @@ pub struct VecPoly3(
 );
 
 /// Represents a degree-2 scalar polynomial \\(a + b \cdot x + c \cdot x^2\\)
+#[derive(ZeroizeOnDrop)]
 pub struct Poly2(pub Scalar, pub Scalar, pub Scalar);
 
 /// Represents a degree-6 scalar polynomial, without the zeroth degree
@@ -161,58 +164,10 @@ impl Poly2 {
 }
 
 #[cfg(feature = "yoloproofs")]
+#[derive(ZeroizeOnDrop)]
 impl Poly6 {
     pub fn eval(&self, x: Scalar) -> Scalar {
         x * (self.t1 + x * (self.t2 + x * (self.t3 + x * (self.t4 + x * (self.t5 + x * self.t6)))))
-    }
-}
-
-impl Drop for VecPoly1 {
-    fn drop(&mut self) {
-        for e in self.0.iter_mut() {
-            e.clear();
-        }
-        for e in self.1.iter_mut() {
-            e.clear();
-        }
-    }
-}
-
-impl Drop for Poly2 {
-    fn drop(&mut self) {
-        self.0.clear();
-        self.1.clear();
-        self.2.clear();
-    }
-}
-
-#[cfg(feature = "yoloproofs")]
-impl Drop for VecPoly3 {
-    fn drop(&mut self) {
-        for e in self.0.iter_mut() {
-            e.clear();
-        }
-        for e in self.1.iter_mut() {
-            e.clear();
-        }
-        for e in self.2.iter_mut() {
-            e.clear();
-        }
-        for e in self.3.iter_mut() {
-            e.clear();
-        }
-    }
-}
-
-#[cfg(feature = "yoloproofs")]
-impl Drop for Poly6 {
-    fn drop(&mut self) {
-        self.t1.clear();
-        self.t2.clear();
-        self.t3.clear();
-        self.t4.clear();
-        self.t5.clear();
-        self.t6.clear();
     }
 }
 
@@ -269,6 +224,7 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+    use zeroize::Zeroize;
     use super::*;
 
     #[test]
@@ -355,7 +311,7 @@ mod tests {
         let mut v = vec![Scalar::from(24u64), Scalar::from(42u64)];
 
         for e in v.iter_mut() {
-            e.clear();
+            e.zeroize();
         }
 
         fn flat_slice<T>(x: &[T]) -> &[u8] {
@@ -378,9 +334,9 @@ mod tests {
             Scalar::from(255u64),
         );
 
-        v.0.clear();
-        v.1.clear();
-        v.2.clear();
+        v.0.zeroize();
+        v.1.zeroize();
+        v.2.zeroize();
 
         fn as_bytes<T>(x: &T) -> &[u8] {
             use core::mem;


### PR DESCRIPTION
`clear_on_drop` is not compatible with `wasm32-unknown-unknown` on MacOS and got no new update for 2 years.

I replaced it by `ZeroizeOnDrop` to have the same behavior.

